### PR TITLE
Init vue.config.js

### DIFF
--- a/vue-cli/vue.config.js
+++ b/vue-cli/vue.config.js
@@ -1,0 +1,11 @@
+// vue.config.js
+
+/**
+ * @type {import('@vue/cli-service').ProjectOptions}
+ */
+module.exports = {
+  devServer: {
+    port: 9999,
+  },
+  publicPath: '/otus-vue-deploy/',
+};


### PR DESCRIPTION
Конфигурация для ```vuejs``` с переопределением двух параметров:

- Порт по-умолчанию для webpack dev server
- Расположение проекта НЕ в корневом url